### PR TITLE
Use seperate PHPStan step in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 on: [push, pull_request]
 
+env:
+    PHP_EXTENSIONS: dom
+
 jobs:
     phpunit:
         name: PHP ${{ matrix.php }} on ${{ matrix.os }} (${{ matrix.dependency-version }})
@@ -17,7 +20,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: dom
+                  extensions: $PHP_EXTENSIONS
                   coverage: none
 
             - name: Restore Composer dependencies
@@ -49,7 +52,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: latest
-                  extensions: dom
+                  extensions: $PHP_EXTENSIONS
                   coverage: none
 
             - name: Restore Composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-    test:
+    phpunit:
         name: PHP ${{ matrix.php }} on ${{ matrix.os }} (${{ matrix.dependency-version }})
         runs-on: ${{ matrix.os }}
         strategy:
@@ -36,8 +36,37 @@ jobs:
                   dependency-versions: ${{ matrix.dependency-version }}
                   composer-options: "--prefer-dist"
 
-            - name: Execute PHPUnit tests
+            - name: Run PHPUnit tests
               run: composer test
+
+    phpstan:
+        name: Static analysis
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3.5.3
+
+            - name: Configure PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: latest
+                  extensions: dom
+                  coverage: none
+
+            - name: Restore Composer dependencies
+              id: cache-php
+              uses: actions/cache@v3
+              with:
+                  path: vendor
+                  key: ${{ matrix.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-php-
+
+            - name: Install dependencies
+              if: steps.cache-php.outputs.cache-hit != 'true'
+              uses: ramsey/composer-install@v2
+              with:
+                  dependency-versions: highest
+                  composer-options: "--prefer-dist"
 
             - name: Run PHPStan analysis
               run: composer analyse


### PR DESCRIPTION
We don't have to run PHPStan in multiple PHP versions and/or dependency permutations, so we'll extract it into its own step in the workflow file.