### PR TITLE
Run tests on PHP 8.3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                php: [8.1, 8.2]
+                php: [8.1, 8.2, 8.3]
                 dependency-version: [highest, lowest]
         steps:
             - uses: actions/checkout@v4.1.1


### PR DESCRIPTION
This PR adds PHP 8.3 to the workflow file to make sure this library is tested against this latest PHP version.